### PR TITLE
解决几个和原生select保持一致的问题

### DIFF
--- a/src/select.js
+++ b/src/select.js
@@ -117,7 +117,7 @@ define(function(require, exports, module) {
         setup: function() {
             var trigger = this.get('trigger');
 
-            this.delegateEvents(trigger, "click", this._trigger_click);
+            this.delegateEvents(trigger, "mousedown", this._triggerHandle);
 
             this.delegateEvents(trigger, 'mouseenter', function(e) {
                 trigger.addClass(getClassName(this.get('classPrefix'), 'trigger-hover'));
@@ -168,11 +168,10 @@ define(function(require, exports, module) {
             this.set('align', align);
         },
 
-        _trigger_click: function(e) {
-            var self = this;
+        _triggerHandle: function(e) {
             e.preventDefault();
-            if (!self.get('disabled')) {
-                self.show();
+            if (!this.get('disabled')) {
+                this.show();
             }
         },
 

--- a/tests/select-spec.js
+++ b/tests/select-spec.js
@@ -347,7 +347,7 @@ define(function(require) {
                 .to.be('true');
         });
 
-        it('trigger click', function() {
+        it('trigger mousedown', function() {
             trigger = $('<a href="#" id="example"></a>').appendTo(document.body);
             select = new Select({
                 trigger: '#example',
@@ -357,7 +357,7 @@ define(function(require) {
                 ]
             }).render();
 
-            trigger.click();
+            trigger.mousedown();
             expect(select.element.is(':hidden')).to.be(false);
             select.hide();
             expect(select.element.is(':hidden')).to.be(true);
@@ -374,13 +374,13 @@ define(function(require) {
                 disabled: true
             }).render();
 
-            trigger.click();
+            trigger.mousedown();
             expect(trigger.hasClass('ui-select-disabled')).to.be(true);
             expect(select.element.is(':hidden')).to.be(true);
             select.hide();
 
             select.set('disabled', false);
-            trigger.click();
+            trigger.mousedown();
             expect(trigger.hasClass('ui-select-disabled')).to.be(false);
             expect(select.element.is(':hidden')).to.be(false);
         });


### PR DESCRIPTION
1. https://github.com/aralejs/select/issues/37 item 区域的click点击不应该冒泡
2. https://github.com/aralejs/select/issues/46 trigger 的触发方式应该是 mousedown
