### PR TITLE
Fix bug selected

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ sea-modules
 _site
 dist
 spm_modules
+coverage

--- a/index.css
+++ b/index.css
@@ -1,1 +1,1 @@
-@import url("alice-select");
+@import url("~alice-select");

--- a/src/select.handlebars
+++ b/src/select.handlebars
@@ -1,12 +1,12 @@
 <div class="{{classPrefix}}">
     <ul class="{{classPrefix}}-content" data-role="content">
-        {{#each select}}
+        {{#each options}}
         <li data-role="item"
           class="{{../classPrefix}}-item {{#if disabled}}{{../../classPrefix}}-item-disabled{{/if}}"
           data-value="{{value}}"
-          data-defaultSelected="{{output defaultSelected}}"
-          data-selected="{{output selected}}"
-          data-disabled="{{output disabled}}">{{{text}}}</li>
+          data-defaultSelected="{{toString defaultSelected}}"
+          data-selected="{{toString selected}}"
+          data-disabled="{{toString disabled}}">{{{text}}}</li>
         {{/each}}
     </ul>
 </div>

--- a/src/select.js
+++ b/src/select.js
@@ -63,7 +63,7 @@ var Select = Overlay.extend({
     },
 
     templateHelpers: {
-        output: function(data) {
+        toString: function(data) {
             return data + '';
         }
     },
@@ -162,10 +162,10 @@ var Select = Overlay.extend({
         // 同步 html 到 model
         var model = this.get('model');
         if (oldSelectIndex >= 0) {
-            model.select[oldSelectIndex].selected = false;
+            model.options[oldSelectIndex].selected = false;
         }
         if (selectIndex >= 0) {
-            model.select[selectIndex].selected = true;
+            model.options[selectIndex].selected = true;
         }
         this.set('model', model);
 
@@ -206,7 +206,7 @@ var Select = Overlay.extend({
     },
 
     addOption: function(option) {
-        var model = this.get("model").select;
+        var model = this.get("model").options;
         model.push(option);
         this.syncModel(model);
         return this;
@@ -235,7 +235,7 @@ var Select = Overlay.extend({
 
     enableOption: function(option) {
         var index = getOptionIndex(option, this.options);
-        var model = this.get("model").select;
+        var model = this.get("model").options;
         model[index].disabled = false;
         this.syncModel(model);
         return this;
@@ -243,7 +243,7 @@ var Select = Overlay.extend({
 
     disableOption: function(option) {
         var index = getOptionIndex(option, this.options);
-        var model = this.get("model").select;
+        var model = this.get("model").options;
         model[index].disabled = true;
         this.syncModel(model);
         return this;
@@ -416,7 +416,7 @@ function convertSelect(select, classPrefix) {
     if (!hasDefaultSelect && model.length) {
         model[0].selected = 'true';
     }
-    return {select: model, classPrefix: classPrefix};
+    return {options: model, classPrefix: classPrefix};
 }
 
 // 补全 model 对象
@@ -438,7 +438,7 @@ function completeModel(model, classPrefix) {
     } else { //当所有都没有设置 selected 则默认设置第一个
         newModel[0].selected = true;
     }
-    return {select: newModel, classPrefix: classPrefix};
+    return {options: newModel, classPrefix: classPrefix};
 }
 
 function getOptionIndex(option, options) {

--- a/tests/select-spec.js
+++ b/tests/select-spec.js
@@ -54,7 +54,7 @@ describe('select', function() {
                 trigger: '#example'
             }).render();
 
-            var model = select.get("model").select;
+            var model = select.get("model").options;
             expect(model[0].defaultSelected).to.be(false);
             expect(model[0].selected).to.be(true);
             expect(model[0].value).to.be('value1');
@@ -71,7 +71,7 @@ describe('select', function() {
                 trigger: '#example'
             }).render();
 
-            var model = select.get("model").select;
+            var model = select.get("model").options;
             expect(model[0].defaultSelected).to.be(false);
             expect(model[0].selected).to.be(false);
             expect(model[0].value).to.be('value1');
@@ -88,7 +88,7 @@ describe('select', function() {
                 trigger: '#example'
             }).render();
 
-            var model = select.get("model").select;
+            var model = select.get("model").options;
             expect(model[0].disabled).to.be(false);
             expect(model[1].disabled).to.be(true);
         });
@@ -99,7 +99,7 @@ describe('select', function() {
                 trigger: '#example'
             }).render();
 
-            var model = select.get("model").select;
+            var model = select.get("model").options;
             expect(model[0].defaultSelected).to.be(true);
             expect(model[0].selected).to.be(false);
             expect(model[0].value).to.be('value1');
@@ -120,7 +120,7 @@ describe('select', function() {
                 ]
             }).render();
 
-            var model = select.get("model").select;
+            var model = select.get("model").options;
             expect(model[0].defaultSelected).to.be(false);
             expect(model[0].selected).to.be(true);
             expect(model[0].value).to.be('value1');
@@ -141,7 +141,7 @@ describe('select', function() {
                 ]
             }).render();
 
-            var model = select.get("model").select;
+            var model = select.get("model").options;
             expect(model[0].defaultSelected).to.be(false);
             expect(model[0].selected).to.be(false);
             expect(model[0].value).to.be('value1');
@@ -162,7 +162,7 @@ describe('select', function() {
                 ]
             }).render();
 
-            var model = select.get("model").select;
+            var model = select.get("model").options;
             expect(model[0].defaultSelected).to.be(true);
             expect(model[0].selected).to.be(false);
             expect(model[0].value).to.be('value1');
@@ -179,7 +179,7 @@ describe('select', function() {
                 trigger: '#example'
             }).render();
 
-            var model = select.get("model").select;
+            var model = select.get("model").options;
             expect(model.length).to.be(0);
         });
 
@@ -639,11 +639,11 @@ describe('select', function() {
             ]
         }).render();
         select.select(0);
-        expect(select.get('model').select[0].selected).to.be.ok();
+        expect(select.get('model').options[0].selected).to.be.ok();
         select.select(1);
-        expect(select.get('model').select[1].selected).to.be.ok();
+        expect(select.get('model').options[1].selected).to.be.ok();
         select.select(2);
-        expect(select.get('model').select[2].selected).to.be.ok();
+        expect(select.get('model').options[2].selected).to.be.ok();
     });
 
     it('html original select should be visiable', function() {
@@ -666,9 +666,9 @@ describe('select', function() {
                 {value: 'value4', text: 'text4', selected: true}
             ]
         }).render();
-        expect(select.get('model').select[0].selected).not.to.be.ok();
-        expect(select.get('model').select[1].selected).not.to.be.ok();
-        expect(select.get('model').select[2].selected).not.to.be.ok();
-        expect(select.get('model').select[3].selected).to.be.ok();
+        expect(select.get('model').options[0].selected).not.to.be.ok();
+        expect(select.get('model').options[1].selected).not.to.be.ok();
+        expect(select.get('model').options[2].selected).not.to.be.ok();
+        expect(select.get('model').options[3].selected).to.be.ok();
     })
 });


### PR DESCRIPTION
0.10.0 的默认选中有 bug，Demo: http://meowtec.github.io/demo/arale-select-bugs/before.html

经过排除发现是模板中的 `select` 属性和 `output` helper 造成的问题。似乎这两个名字都是 Handlebars 内部关键字之类的东西，或者是 Handlebars 的 bug，不过我没有找到相关文档。

只有同时把他们都改成其他的名字，默认选中的问题才可以解决。
 - 如果只改 output -> toString，则 build 会报错。
 - 如果只改 select -> options，bug 还会存在。

tests case 也做了相应修改
修改后 Demo: http://meowtec.github.io/demo/arale-select-bugs/after.html
